### PR TITLE
Fix the author name of pixel RNN

### DIFF
--- a/_posts/2016-06-11-oord16.md
+++ b/_posts/2016-06-11-oord16.md
@@ -22,7 +22,8 @@ order: 1747
 cycles: false
 author:
 - given: Aäron
-  family: van den Oord
+  prefix: van den
+  family: Oord
 - given: Nal
   family: Kalchbrenner
 - given: Koray

--- a/_posts/2016-06-11-oord16.md
+++ b/_posts/2016-06-11-oord16.md
@@ -21,8 +21,8 @@ page: 1747-1756
 order: 1747
 cycles: false
 author:
-- given: Aaron Van
-  family: Oord
+- given: Aäron
+  family: van den Oord
 - given: Nal
   family: Kalchbrenner
 - given: Koray


### PR DESCRIPTION
Summary: Fix the first author's name.


---

I think the name of van den Oord looks wrong on https://proceedings.mlr.press/v48/oord16.html:

<img width="330" alt="Screenshot 2022-06-01 at 17 47 57" src="https://user-images.githubusercontent.com/7121753/171365660-c946a647-d497-4d53-86cf-534ce58a787b.png">

According to [its PDF paper](http://proceedings.mlr.press/v48/oord16.pdf), the expected name is 

<img width="752" alt="Screenshot 2022-06-01 at 17 45 31" src="https://user-images.githubusercontent.com/7121753/171365091-b8d4d532-ad71-454a-8999-9a966ad29e50.png">

By following the pdf's name, the page will be 

<img width="500" alt="Screenshot 2022-06-01 at 17 46 44" src="https://user-images.githubusercontent.com/7121753/171366033-f0a211a2-0c5b-4cda-a368-7d1206920e6f.png">

by merging this PR.


Best regards,